### PR TITLE
Implement rate limiting for LLM API calls

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -43,6 +43,7 @@ class Configuration:
     writer_provider: WriterProvider = WriterProvider.ANTHROPIC # Defaults to Anthropic as provider
     writer_model: str = "claude-3-5-sonnet-latest" # Defaults to Anthropic as provider
     search_api: SearchAPI = SearchAPI.TAVILY # Default to TAVILY
+    rate_limit: Optional[int] = None # Rate limit for API calls (requests per minute)
 
     @classmethod
     def from_runnable_config(


### PR DESCRIPTION
Implement rate limiting for LLM API calls using `InMemoryRateLimiter`.

* **Configuration**:
  - Add `rate_limit` field to `Configuration` class in `src/open_deep_research/configuration.py`.
  - Update `from_runnable_config` method to include `rate_limit` field.

* **Graph**:
  - Import `InMemoryRateLimiter` from `langchain_core.rate_limiters` in `src/open_deep_research/graph.py`.
  - Initialize rate limiter with `rate_limit` value from configuration.
  - Wrap `structured_llm.invoke` calls in `generate_report_plan`, `generate_queries`, `write_section`, and `write_final_sections` functions with the rate limiter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/santiago-afonso/open_deep_research/pull/1?shareId=eae7f92e-eb1e-4a1a-98a0-77ac1f1d3a52).